### PR TITLE
First look at #8

### DIFF
--- a/src/NhanAZ/BlockData/BlockDataChunkListener.php
+++ b/src/NhanAZ/BlockData/BlockDataChunkListener.php
@@ -1,0 +1,37 @@
+<?php
+/*
+ * Copyright (C) 2020 kostamax27
+ */
+
+declare(strict_types=1);
+
+namespace NhanAZ\BlockData;
+
+use pocketmine\math\Vector3;
+use pocketmine\world\ChunkListener;
+use pocketmine\world\ChunkListenerNoOpTrait;
+use pocketmine\world\format\Chunk;
+use pocketmine\world\World;
+
+class BlockDataChunkListener implements ChunkListener{
+	use ChunkListenerNoOpTrait;
+
+	public function __construct(
+		private readonly BlockData $blockData,
+		private readonly World $world,
+	){}
+
+	public function onChunkChanged(int $chunkX, int $chunkZ, Chunk $chunk) : void{
+		//TODO: ...
+	}
+
+	public function onBlockChanged(Vector3 $block) : void{
+		//TODO: strict block modification checking???
+		$this->blockData->removeAt(
+			$this->world,
+			$block->getFloorX(),
+			$block->getFloorY(),
+			$block->getFloorZ(),
+		);
+	}
+}

--- a/src/NhanAZ/BlockData/BlockDataListener.php
+++ b/src/NhanAZ/BlockData/BlockDataListener.php
@@ -4,10 +4,6 @@ declare(strict_types=1);
 
 namespace NhanAZ\BlockData;
 
-use pocketmine\event\block\BlockBreakEvent;
-use pocketmine\event\block\BlockBurnEvent;
-use pocketmine\event\block\LeavesDecayEvent;
-use pocketmine\event\entity\EntityExplodeEvent;
 use pocketmine\event\Listener;
 use pocketmine\event\plugin\PluginDisableEvent;
 use pocketmine\event\world\ChunkLoadEvent;
@@ -25,7 +21,6 @@ final class BlockDataListener implements Listener{
 	public function __construct(
 		private BlockData $blockData,
 		private PluginBase $plugin,
-		private bool $autoCleanup,
 	){}
 
 	// ── World & Chunk Lifecycle ──────────────────────────────────────
@@ -87,58 +82,6 @@ final class BlockDataListener implements Listener{
 	public function onPluginDisable(PluginDisableEvent $event) : void{
 		if($event->getPlugin() === $this->plugin){
 			$this->blockData->closeAll();
-		}
-	}
-
-	// ── Auto Cleanup (only active when $autoCleanup is true) ─────────
-
-	/**
-	 * Removes block data when a player breaks the block.
-	 *
-	 * @param BlockBreakEvent $event
-	 * @priority MONITOR
-	 */
-	public function onBlockBreak(BlockBreakEvent $event) : void{
-		if($this->autoCleanup){
-			$this->blockData->remove($event->getBlock());
-		}
-	}
-
-	/**
-	 * Removes block data for all blocks destroyed by an explosion.
-	 *
-	 * @param EntityExplodeEvent $event
-	 * @priority MONITOR
-	 */
-	public function onEntityExplode(EntityExplodeEvent $event) : void{
-		if($this->autoCleanup){
-			foreach($event->getBlockList() as $block){
-				$this->blockData->remove($block);
-			}
-		}
-	}
-
-	/**
-	 * Removes block data when a block is burned by fire.
-	 *
-	 * @param BlockBurnEvent $event
-	 * @priority MONITOR
-	 */
-	public function onBlockBurn(BlockBurnEvent $event) : void{
-		if($this->autoCleanup){
-			$this->blockData->remove($event->getBlock());
-		}
-	}
-
-	/**
-	 * Removes block data when leaves decay naturally.
-	 *
-	 * @param LeavesDecayEvent $event
-	 * @priority MONITOR
-	 */
-	public function onLeavesDecay(LeavesDecayEvent $event) : void{
-		if($this->autoCleanup){
-			$this->blockData->remove($event->getBlock());
 		}
 	}
 }

--- a/src/NhanAZ/BlockData/BlockDataWorld.php
+++ b/src/NhanAZ/BlockData/BlockDataWorld.php
@@ -22,8 +22,8 @@ final class BlockDataWorld{
 	private LevelDB $db;
 
 	/**
-	 * In-memory cache: blockHash => stored data (or null if confirmed empty).
-	 * Entries are populated on first read and evicted on chunk unload.
+	 * In-memory cache: blockHash => stored data.
+	 * Only non-null values are cached; cache entries are evicted on chunk unload.
 	 * @var array<int, mixed>
 	 */
 	private array $cache = [];
@@ -79,8 +79,11 @@ final class BlockDataWorld{
 			$data = null;
 		}
 
-		$this->cache[$hash] = $data;
-		$this->trackBlock($x, $z, $hash);
+		// Only cache non-null values to avoid unbounded "dead cache" growth
+		if($data !== null){
+			$this->cache[$hash] = $data;
+			$this->trackBlock($x, $z, $hash);
+		}
 
 		return $data;
 	}


### PR DESCRIPTION
# Problems

At the moment, there are several issues that do not yet have a clear solution:

1. ~Do we actually need multiple instances of `BlockDataChunkListener`, one per world?~
2. There is an issue with `BlockDataChunkListener`: if a developer tries to update a block (for example, set the same block to its current position), the listener removes the associated data.
3. ...

# Tests

This feature has not been tested yet.